### PR TITLE
New API for receipt checks on start (bug 981235)

### DIFF
--- a/lib/fxpay.js
+++ b/lib/fxpay.js
@@ -19,9 +19,6 @@
       onerror: function(err) {
         throw err;
       },
-      onpurchase: function(info) {
-        settings.log('product purchased:', info);
-      },
       oninit: function() {
         settings.log('all products set up successfully');
       }
@@ -51,11 +48,16 @@
     if (opt.onerror) {
       settings.callbacks.onerror = opt.onerror;
     }
-    if (opt.onpurchase) {
-      settings.callbacks.onpurchase = opt.onpurchase;
-    }
     if (opt.oninit) {
       settings.callbacks.oninit = opt.oninit;
+    }
+
+    var validOptions = ['onerror', 'oninit'];
+    for (var k in opt) {
+      if (validOptions.indexOf(k) === -1) {
+        settings.log.error('init() received an unknown option:', k);
+        return settings.callbacks.onerror('INCORRECT_USAGE');
+      }
     }
 
     if (!settings.mozApps || !settings.mozApps.getSelf) {
@@ -101,26 +103,34 @@
   };
 
 
-  exports.purchase = function _purchase(productId, opt) {
+  exports.purchase = function _purchase(productId, onPurchase, opt) {
     opt = opt || {};
     opt.maxTries = opt.maxTries || undefined;
     opt.pollIntervalMs = opt.pollIntervalMs || undefined;
+    if (!onPurchase) {
+      onPurchase = function _onPurchase(err, info) {
+        if (err) {
+          throw err;
+        }
+        console.log('product', info.productId, 'purchased');
+      };
+    }
 
     if (settings.initError) {
       settings.log.error('init failed:', settings.initError);
-      return settings.callbacks.onerror(settings.initError);
+      return onPurchase(settings.initError);
     }
 
     if (!settings.mozPay) {
       settings.log.error('Missing pay platform: mozPay was falsey');
-      return settings.callbacks.onerror('PAY_PLATFORM_UNAVAILABLE');
+      return onPurchase('PAY_PLATFORM_UNAVAILABLE');
     }
 
-    startPurchase(productId, settings.appSelf, opt);
+    startPurchase(productId, onPurchase, settings.appSelf, opt);
   };
 
 
-  function startPurchase(productId, appSelf, opt) {
+  function startPurchase(productId, onPurchase, appSelf, opt) {
     opt = opt || {};
     opt.maxTries = opt.maxTries || undefined;
     opt.pollIntervalMs = opt.pollIntervalMs || undefined;
@@ -135,7 +145,7 @@
     var path = "/webpay/inapp/prepare/";
     api.post(path, {inapp: productId}, function(err, productData) {
       if (err) {
-        return settings.callbacks.onerror(err);
+        return onPurchase(err);
       }
       log.debug('xhr load: JSON', productData);
 
@@ -143,7 +153,7 @@
 
       payReq.onerror = function() {
         log.error('mozPay: received onerror():', this.error.name);
-        settings.callbacks.onerror(this.error.name);
+        onPurchase(this.error.name);
       };
 
       payReq.onsuccess = function() {
@@ -156,7 +166,7 @@
             productData.contribStatusURL,
             {versioned: false}
           ), function(err, data) {
-            onTransaction(err, data, appSelf, info);
+            onTransaction(err, onPurchase, data, appSelf, info);
           }, {
             maxTries: opt.maxTries,
             pollIntervalMs: opt.pollIntervalMs
@@ -167,9 +177,9 @@
   }
 
 
-  function onTransaction(err, data, appSelf, info) {
+  function onTransaction(err, onPurchase, data, appSelf, info) {
     if (err) {
-      return settings.callbacks.onerror(err);
+      return onPurchase(err);
     }
     settings.log.info('received completed transaction:', data);
 
@@ -178,13 +188,13 @@
 
     receiptReq.onsuccess = function() {
       settings.log.info('item fully purchased and receipt installed');
-      settings.callbacks.onpurchase(info);
+      onPurchase(null, info);
     };
 
     receiptReq.onerror = function() {
       var err = this.error.name;
       settings.log.error('error calling app.addReceipt', err);
-      settings.callbacks.onerror(err);
+      onPurchase(err);
     };
   }
 
@@ -236,7 +246,7 @@
     opt = opt || {};
     this.baseUrl = baseUrl;
     this.log = settings.log;
-    this.timeoutMs = settings.apiTimeoutMs || 5000;
+    this.timeoutMs = settings.apiTimeoutMs || 10000;
     this.versionPrefix = settings.apiVersionPrefix || undefined;
   }
 


### PR DESCRIPTION
Any r on the new API? You could ignore all the diff churn and just check the readme.

This change sets the stage for receipt verification which needs to happen when an app first loads. The purchase function will now invoke the same `onpurchase()` callback as receipt restoration would. However, receipt restoration will land in a future bug.
