### PR TITLE
Restore inapp GUID correctly (bug 1058112)

### DIFF
--- a/lib/fxpay.js
+++ b/lib/fxpay.js
@@ -392,7 +392,7 @@
       params[parts[0]] = decodeURIComponent(parts[1]);
     });
 
-    productInfo.productId = parseInt(params.inapp_id, 10);
+    productInfo.productId = params.inapp_id;
 
     if (!productInfo.productId) {
       settings.log.error('Could not find productId in storedata:',

--- a/tests/test-fxpay.js
+++ b/tests/test-fxpay.js
@@ -868,7 +868,7 @@ describe('fxpay', function () {
     });
 
     it('passes through receipt data', function(done) {
-      var productId = 321;
+      var productId = 'some-guid';
       var productUrl = 'app://some-packaged-origin';
       var storedata = 'inapp_id=' + productId;
       appSelf.origin = productUrl;
@@ -878,7 +878,6 @@ describe('fxpay', function () {
                               function(err, data, info) {
         if (!err) {
           assert.equal(info.productId, productId);
-          assert.equal(typeof info.productId, 'number');
           assert.equal(info.productUrl, productUrl);
           assert.equal(data.product.storedata, storedata);
         }


### PR DESCRIPTION
Store data from receipts was not parsed correctly.
