### PR TITLE
Fix invalidStateError in xhr for IE

### DIFF
--- a/lib/fxpay/api.js
+++ b/lib/fxpay/api.js
@@ -115,8 +115,11 @@
     }
 
     log.debug('opening', method, 'to', url);
-    xhr.timeout = api.timeoutMs;
     xhr.open(method, url, true);
+
+    // Has to be after xhr.open to avoid
+    // invalidStateError in IE.
+    xhr.timeout = api.timeoutMs;
 
     for (var hdr in opt.headers) {
       xhr.setRequestHeader(hdr, opt.headers[hdr]);


### PR DESCRIPTION
We probably don't care about IE now, but I wanted to see where things broke.

This change fixes the product retrieval.