### PR TITLE
Fix callback leakage (bug 1117878)

### DIFF
--- a/tests/helper.js
+++ b/tests/helper.js
@@ -146,6 +146,8 @@
     reset: function() {
       this._receipt = null;
       this.error = null;
+      this.onsuccess = function() {};
+      this.onerror = function() {};
     }
   };
 


### PR DESCRIPTION
Saw that the callback here: https://github.com/mozilla/fxpay/blob/master/tests/test-purchase.js#L232 was being called in later tests in certain circumstances. The cause looks to be the receipt success callback was set but never restored by reset().