### PR TITLE
Move in-app logic into adapater (bug 1113801)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,7 @@ var libFiles = [
   __dirname + '/lib/fxpay/pay.js',
   __dirname + '/lib/fxpay/products.js',
   __dirname + '/lib/fxpay/receipts.js',
+  __dirname + '/lib/fxpay/adapter.js',
   __dirname + '/lib/fxpay/index.js',
 ];
 

--- a/README.rst
+++ b/README.rst
@@ -135,6 +135,7 @@ Changelog
   source before you can use it. That is, unless you install the library
   with Bower.
 * Added a source map alongside minified source file.
+* Added adapter class for swappable fxpay API backends.
 
 **0.0.4** (2014-09-17)
 

--- a/lib/fxpay/adapter.js
+++ b/lib/fxpay/adapter.js
@@ -1,0 +1,169 @@
+(function() {
+  'use strict';
+
+  var exports = window.fxpay.utils.namespace('fxpay.adapter');
+
+  var API = require('fxpay/api').API;
+  var products = require('fxpay/products');
+  var receipts = require('fxpay/receipts');
+  var settings = require('fxpay/settings');
+  var utils = require('fxpay/utils');
+
+
+  function FxInappAdapter() {
+    //
+    // Adapter for Firefox Marketplace in-app products.
+    //
+    // This implements the backend details about how a
+    // purchase JWT is generated and it has some hooks for
+    // initialization and finishing up purchases.
+    //
+    // This is the default adapter and serves as a guide
+    // for what public methods you need to implement if you
+    // were to create your own.
+    //
+    settings.log.info('using Firefox Marketplace In-App adapter');
+    this.api = new API(settings.apiUrlBase);
+  }
+
+  FxInappAdapter.prototype.init = function(callback) {
+    //
+    // Initialize the payment system.
+    //
+    // This is called when the fxpay library itself is initialized.
+    // This is a chance to restore purchases or anything that should
+    // happen when an app starts up.
+    //
+    // This must execute callback(error) when finished.
+    // The error parameter should be null when there are no errors.
+    //
+    if (!settings.hasAddReceipt && !settings.localStorage) {
+      settings.log.error('no way to store receipts on this platform');
+      return callback('PAY_PLATFORM_UNAVAILABLE');
+    }
+    if (settings.appSelf &&
+        settings.window.location.href.indexOf('app://') === 0 &&
+        !settings.appSelf.manifest.origin) {
+      settings.log.error('packaged app did not define an origin so ' +
+                         'we have no key to look up products');
+      return callback('UNDEFINED_APP_ORIGIN');
+    }
+    var numReceipts = 0;
+    var receipt;
+    var allReceipts = receipts.all();
+    for (var i = 0; i < allReceipts.length; i++) {
+      receipt = allReceipts[i];
+      settings.log.info('Installed receipt: ' + receipt);
+      numReceipts++;
+      receipts.verify(receipt, settings.onrestore);
+    }
+    settings.log.info('Number of receipts installed: ' + numReceipts);
+    callback();
+  };
+
+  FxInappAdapter.prototype.startTransaction = function(opt, callback) {
+    //
+    // Start a transaction.
+    //
+    // The `opt` object contains the following parameters:
+    //
+    // - productId: the ID of the product purchased.
+    //
+    // When finished, execute callback(error, transactionData).
+    //
+    // - error: an error if one occurred or null if not
+    // - transactionData: an object that describes the transaction.
+    //   This can be specific to your adapter but must include
+    //   the `productJWT` parameter which is a JSON Web Token
+    //   that can be passed to navigator.mozPay().
+    //
+    opt = utils.defaults(opt, {
+      productId: null
+    });
+    var self = this;
+    self.api.post(settings.prepareJwtApiUrl, {inapp: opt.productId},
+                  function(err, productData) {
+      if (err) {
+        return callback(err);
+      }
+      settings.log.debug('requested JWT for ', opt.productId, 'from API; got:',
+                         productData);
+      return callback(null, {productJWT: productData.webpayJWT,
+                             productId: opt.productId,
+                             productData: productData});
+    });
+  };
+
+  FxInappAdapter.prototype.transactionStatus = function(transData, callback) {
+    //
+    // Get the status of a transaction.
+    //
+    // The `transData` object received is the same one returned by
+    // startTransaction().
+    //
+    // When finished, execute callback(error, isCompleted, productInfo).
+    //
+    // - error: an error if one occurred or null if not.
+    // - isCompleted: true or false if the transaction has been
+    //   completed successfully.
+    // - productInfo: an object that describes the product purchased.
+    //   If there was an error or the transaction was not completed,
+    //   this can be null.
+    //   A productInfo object should have the propeties described at:
+    //
+    //   https://developer.mozilla.org/en-US/Marketplace/Monetization
+    //   /In-app_payments_section/fxPay_iap#Product_Info_Object
+    //
+    var self = this;
+
+    var url = self.api.url(transData.productData.contribStatusURL,
+                           {versioned: false});
+    self.api.get(url, function(err, data) {
+      if (err) {
+        return callback(err);
+      }
+      if (data.status === 'complete') {
+        self._finishTransaction(data, transData.productId,
+                                function(err, productInfo) {
+          if (err) {
+            return callback(err);
+          }
+          callback(null, true, productInfo);
+        });
+      } else if (data.status === 'incomplete') {
+        return callback(null, false);
+      } else {
+        settings.log.error('transaction status', data.status, 'from',
+                           url, 'was unexpected');
+        return callback('INVALID_TRANSACTION_STATE');
+      }
+    });
+  };
+
+  FxInappAdapter.prototype._finishTransaction = function(data, productId,
+                                                         callback) {
+    //
+    // Private helper method to finish transactionStatus().
+    //
+    settings.log.info('received completed transaction:', data);
+
+    receipts.add(data.receipt, function(err) {
+      if (err) {
+        return callback(err);
+      }
+      products.getById(productId, function(err, fullProductInfo) {
+        if (err) {
+          return callback(err, fullProductInfo);
+        }
+        callback(null, fullProductInfo);
+      }, {
+        // If this is a purchase for fake products, only fetch stub products.
+        fetchStubs: settings.fakeProducts
+      });
+    });
+  };
+
+
+  exports.FxInappAdapter = FxInappAdapter;
+
+})();

--- a/lib/fxpay/index.js
+++ b/lib/fxpay/index.js
@@ -3,11 +3,9 @@
 
   var exports = window.fxpay.utils.namespace('fxpay');
 
-  var API = require('fxpay/api').API;
   var pay = require('fxpay/pay');
   var settings = require('fxpay/settings');
   var products = require('fxpay/products');
-  var receipts = require('fxpay/receipts');
   var utils = require('fxpay/utils');
 
   //
@@ -43,31 +41,15 @@
       settings.hasAddReceipt = (settings.appSelf &&
                                 settings.appSelf.addReceipt);
 
-      if (!settings.hasAddReceipt && !settings.localStorage) {
-        settings.log.error('no way to store receipts on this platform');
-        return storeError('PAY_PLATFORM_UNAVAILABLE');
-      }
-      if (settings.appSelf &&
-          settings.window.location.href.indexOf('app://') === 0 &&
-          !settings.appSelf.manifest.origin) {
-        settings.log.error('packaged app did not define an origin so ' +
-                           'we have no key to look up products');
-        return storeError('UNDEFINED_APP_ORIGIN');
-      }
-      var numReceipts = 0;
-      var receipt;
-      var allReceipts = receipts.all();
-      for (var i = 0; i < allReceipts.length; i++) {
-        receipt = allReceipts[i];
-        settings.log.info('Installed receipt: ' + receipt);
-        numReceipts++;
-        receipts.verify(receipt, settings.onrestore);
-      }
-      settings.log.info('Number of receipts installed: ' + numReceipts);
+      settings.adapter.init(function(err) {
+        if (err) {
+          return storeError(err);
+        }
 
-      // Startup succeeded; clear the stored error.
-      settings.initError = null;
-      settings.oninit();
+        // Initialization succeeded; clear the stored error.
+        settings.initError = null;
+        settings.oninit();
+      });
     });
   };
 
@@ -76,23 +58,59 @@
     opt = opt || {};
     opt.maxTries = opt.maxTries || undefined;
     opt.pollIntervalMs = opt.pollIntervalMs || undefined;
-    var productInfo = {};
+
+    var partialProdInfo = {productId: productId};
+    var log = settings.log;
+    var paymentWindow;
 
     if (!onPurchase) {
-      onPurchase = function _onPurchase(err, info) {
+      onPurchase = function _onPurchase(err, returnedProdInfo) {
         if (err) {
           throw err;
         }
-        console.log('product', info.productId, 'purchased');
+        console.log('product', returnedProdInfo.productId, 'purchased');
       };
     }
 
     if (settings.initError) {
       settings.log.error('init failed:', settings.initError);
-      return onPurchase(settings.initError, productInfo);
+      return onPurchase(settings.initError, partialProdInfo);
     }
 
-    startPurchase(productId, onPurchase, opt);
+    log.debug('starting purchase for product', productId);
+
+    if (!settings.mozPay) {
+      // Open a blank payment window on the same event loop tick
+      // as the click handler. This avoids popup blockers.
+      // TODO: maybe we should inject some HTML/CSS to indicate
+      // loading/progress. We probably also need to display any
+      // errors that might occur from the Ajax request to get a JWT.
+      paymentWindow = utils.openWindow({url: ''});
+    }
+
+    settings.adapter.startTransaction({productId: productId},
+                                      function(err, transData) {
+      if (err) {
+        return onPurchase(err, partialProdInfo);
+      }
+      pay.processPayment(transData.productJWT, function(err) {
+        if (err) {
+          return onPurchase(err, partialProdInfo);
+        }
+
+        // The payment flow has completed. Wait for payment verification.
+
+        waitForTransaction(
+          transData,
+          function(err, fullProductInfo) {
+            onPurchase(err, fullProductInfo || partialProdInfo);
+          }, {
+            maxTries: opt.maxTries,
+            pollIntervalMs: opt.pollIntervalMs
+          }
+        );
+      }, {paymentWindow: paymentWindow});
+    });
   };
 
 
@@ -126,120 +144,40 @@
   }
 
 
-  function startPurchase(productId, onPurchase, opt) {
-    opt = opt || {};
-    opt.maxTries = opt.maxTries || undefined;
-    opt.pollIntervalMs = opt.pollIntervalMs || undefined;
-
-    var info = {productId: productId};
-    var log = settings.log;
-    var api = new API(settings.apiUrlBase);
-
-    log.debug('starting purchase for product', productId);
-
-    var paymentWindow;
-    if (!settings.mozPay) {
-      // Open a blank payment window on the same event loop tick
-      // as the click handler. This avoids popup blockers.
-      // TODO: maybe we should inject some HTML/CSS to indicate
-      // loading/progress. We probably also need to display any
-      // errors that might occur from the Ajax request to get a JWT.
-      paymentWindow = utils.openWindow({url: ''});
-    }
-
-    api.post(settings.prepareJwtApiUrl, {inapp: productId},
-             function(err, productData) {
-      if (err) {
-        return onPurchase(err, info);
-      }
-      log.debug('requested JWT for ', productId, 'from API; got:',
-                productData);
-
-      pay.processPayment([productData.webpayJWT], function(err) {
-        if (err) {
-          return onPurchase(err, info);
-        }
-
-        // The payment flow has completed. Wait for payment verification.
-
-        getTransactionResult(
-          api, api.url(
-            productData.contribStatusURL,
-            {versioned: false}
-          ), function(err, data) {
-            onTransaction(err, onPurchase, data, info);
-          }, {
-            maxTries: opt.maxTries,
-            pollIntervalMs: opt.pollIntervalMs
-          }
-        );
-      }, {paymentWindow: paymentWindow});
-    });
-  }
-
-
-  function onTransaction(err, onPurchase, data, productInfo) {
-    if (err) {
-      return onPurchase(err, productInfo);
-    }
-    settings.log.info('received completed transaction:', data);
-
-    receipts.add(data.receipt, function(err) {
-      if (err) {
-        return onPurchase(err, productInfo);
-      }
-      products.getById(productInfo.productId,
-                       function(err, fullProductInfo) {
-        if (err) {
-          return onPurchase(err, fullProductInfo);
-        }
-        onPurchase(null, fullProductInfo);
-      }, {
-        // If this is a purchase for fake products, only fetch stub products.
-        fetchStubs: settings.fakeProducts
-      });
-    });
-  }
-
-
   // NOTE: if you change this function signature, change the setTimeout below.
-  function getTransactionResult(api, transStatusPath, cb, opt) {
+  function waitForTransaction(transData, cb, opt) {
     opt = opt || {};
     opt.maxTries = opt.maxTries || 10;
     opt.pollIntervalMs = opt.pollIntervalMs || 1000;
     opt._tries = opt._tries || 1;
 
     var log = settings.log;
-    log.debug('Getting transaction state at', transStatusPath,
+    log.debug('Getting transaction state for', transData,
               'tries=', opt._tries);
 
     if (opt._tries > opt.maxTries) {
-      log.error('Giving up on transaction at', transStatusPath,
+      log.error('Giving up on transaction for', transData,
                 'after', opt._tries, 'tries');
       return cb('TRANSACTION_TIMEOUT');
     }
 
-    api.get(transStatusPath, function(err, data) {
+    settings.adapter.transactionStatus(
+        transData, function(err, isComplete, productInfo) {
       if (err) {
         return cb(err);
       }
-
-      if (data.status === 'complete') {
-        return cb(null, data);
-      } else if (data.status === 'incomplete') {
+      if (isComplete) {
+        return cb(null, productInfo);
+      } else {
         log.debug('Re-trying incomplete transaction in',
                   opt.pollIntervalMs, 'ms');
         window.setTimeout(function() {
-          getTransactionResult(api, transStatusPath, cb, {
+          waitForTransaction(transData, cb, {
             maxTries: opt.maxTries,
             pollIntervalMs: opt.pollIntervalMs,
             _tries: opt._tries + 1
           });
         }, opt.pollIntervalMs);
-      } else {
-        log.error('transaction status', data.status, 'from',
-                  transStatusPath, 'was unexpected');
-        return cb('INVALID_TRANSACTION_STATE');
       }
     });
   }

--- a/lib/fxpay/pay.js
+++ b/lib/fxpay/pay.js
@@ -7,12 +7,12 @@
   var utils = require('fxpay/utils');
 
 
-  exports.processPayment = function pay_processPayment(jwts, callback, opt) {
+  exports.processPayment = function pay_processPayment(jwt, callback, opt) {
     opt = opt || {};
     if (settings.mozPay) {
-      settings.log.info('processing payment with mozPay');
+      settings.log.info('processing payment with mozPay using jwt', jwt);
 
-      var payReq = settings.mozPay(jwts);
+      var payReq = settings.mozPay([jwt]);
 
       payReq.onerror = function mozPay_onerror() {
         settings.log.error('mozPay: received onerror():', this.error.name);
@@ -30,7 +30,7 @@
                         'reference to the payment window');
       }
       settings.log.info('processing payment with web flow');
-      return processWebPayment(opt.paymentWindow, jwts[0], callback);
+      return processWebPayment(opt.paymentWindow, jwt, callback);
     }
   };
 

--- a/lib/fxpay/settings.js
+++ b/lib/fxpay/settings.js
@@ -33,6 +33,7 @@
 
     // Private settings.
     //
+    adapter: null,
     // This will be the App object returned from mozApps.getSelf().
     // On platforms that do not implement mozApps it will be null.
     appSelf: null,
@@ -86,6 +87,15 @@
       }
       exports[k] = newSettings[k];
     }
+
+    var DefaultAdapter = require('fxpay/adapter').FxInappAdapter;
+    if (!exports.adapter) {
+      exports.log.info('using default adapter');
+      exports.adapter = new DefaultAdapter();
+    } else {
+      exports.log.info('using custom adapter');
+    }
+
     return exports;
   };
 

--- a/tests/test-purchase.js
+++ b/tests/test-purchase.js
@@ -41,7 +41,8 @@ describe('fxpay.purchase() on B2G', function () {
     var productId = 'some-guid';
     var cfg = {
       apiUrlBase: 'https://not-the-real-marketplace',
-      apiVersionPrefix: '/api/v1'
+      apiVersionPrefix: '/api/v1',
+      adapter: null,
     };
     fxpay.configure(cfg);
 

--- a/tests/test-web-purchase.js
+++ b/tests/test-web-purchase.js
@@ -28,6 +28,7 @@ describe('fxpay.purchase() on the web', function() {
       mozPay: null,
       apiUrlBase: 'https://not-the-real-marketplace',
       apiVersionPrefix: '/api/v1',
+      adapter: null,
       window: {
         location: '',
         open: function() {


### PR DESCRIPTION
@muffinresearch r?

~~I still need to document the adapter methods but~~ this is my idea so far at how to separate out the in-app logic from the Firefox Marketplace logic. Next steps in future patches would be:

- implement a Firefox Marketplace adapter
- re-org the fxpay module so we can build a separate version without any in-app stuff