### PR TITLE
Close window upon early errors (bug 1124889)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,8 @@ Changelog
 
 **0.0.9** (unreleased)
 
+* Fix orphaned payment window (during desktop flow) in some error conditions.
+
 **0.0.8** (2015-01-22)
 
 * Allow scrollbars in popups.

--- a/lib/fxpay/index.js
+++ b/lib/fxpay/index.js
@@ -69,14 +69,13 @@
     }
 
     var partialProdInfo = {productId: productId};
-    var log = settings.log;
 
     if (!onPurchase) {
       onPurchase = function _onPurchase(err, returnedProdInfo) {
         if (err) {
           throw err;
         }
-        console.log('product', returnedProdInfo.productId, 'purchased');
+        settings.log.info('product', returnedProdInfo.productId, 'purchased');
       };
     }
 
@@ -85,7 +84,7 @@
       return onPurchase(settings.initError, partialProdInfo);
     }
 
-    log.debug('starting purchase for product', productId);
+    settings.log.debug('starting purchase for product', productId);
 
     if (!settings.mozPay) {
       if (!opt.paymentWindow) {
@@ -93,23 +92,37 @@
         // as the click handler. This avoids popup blockers.
         opt.paymentWindow = utils.openWindow();
       } else {
-        log.info('web flow will use client provided payment window');
+        settings.log.info('web flow will use client provided payment window');
         utils.reCenterWindow(opt.paymentWindow,
                              settings.winWidth, settings.winHeight);
+      }
+    }
+
+    function closePayWindow() {
+      if (opt.paymentWindow && !opt.paymentWindow.closed) {
+        if (opt.managePaymentWindow) {
+          opt.paymentWindow.close();
+        } else {
+          settings.log.info('payment window should be closed but client ' +
+                            'is managing it');
+        }
       }
     }
 
     settings.adapter.startTransaction({productId: productId},
                                       function(err, transData) {
       if (err) {
+        closePayWindow();
         return onPurchase(err, partialProdInfo);
       }
       pay.processPayment(transData.productJWT, function(err) {
         if (err) {
+          closePayWindow();
           return onPurchase(err, partialProdInfo);
         }
 
-        // The payment flow has completed. Wait for payment verification.
+        // The payment flow has completed and the window has closed.
+        // Wait for payment verification.
 
         waitForTransaction(
           transData,


### PR DESCRIPTION
If there's an error before the payment flow starts we might need to close the payment window.

@muffinresearch r?

This solves the bug for me locally when testing. Once merged, I'll cut a release and bump fireplace for the fix.