### PR TITLE
Add interval to detect popup closure on provider (bug 1124790)

### DIFF
--- a/lib/fxpay/pay.js
+++ b/lib/fxpay/pay.js
@@ -94,6 +94,16 @@
       // load it into the freshly created popup window.
       paymentWindow.location = payUrl;
 
+      // This interval covers closure of the popup
+      // whilst on external domains that won't postMessage
+      // onunload.
+      var popupInterval = setInterval(function() {
+        if (!paymentWindow || paymentWindow.closed) {
+          clearInterval(popupInterval);
+          return callback('DIALOG_CLOSED_BY_USER');
+        }
+      }, 500);
+
       function receivePaymentMessage(event) {
 
         function messageCallback(err) {
@@ -101,6 +111,15 @@
             // These could come from anywhere so ignore them.
             return;
           }
+
+          // We know if we're getting messages from our UI
+          // at this point so we can do away with the
+          // interval watching for the popup closing
+          // whilst on 3rd party domains.
+          if (popupInterval) {
+            clearInterval(popupInterval);
+          }
+
           settings.window.removeEventListener('message',
                                               receivePaymentMessage);
           if (managePaymentWindow) {


### PR DESCRIPTION
So after looking at this I think it makes sense to keep the postMessage and do the interval across the provider part of the flow. This means we don't have to worry about other sources of popup closure.

@kumar303 let me know if you think this sounds like a plan? I'd prepared a spartacus patch to remove the postMessage for unload but I don't think we'll need that.
