### PR TITLE
Fix w/h passed to resizeTo to allow for chrome (bug 1132009)

### DIFF
--- a/lib/fxpay/utils.js
+++ b/lib/fxpay/utils.js
@@ -54,6 +54,11 @@
     h = h || settings.winHeight;
     var xy = exports.getCenteredCoordinates(w, h);
     try {
+      // Allow for the chrome as resizeTo args are the external
+      // window dimensions not the internal ones.
+      w = w + (winRef.outerWidth - winRef.innerWidth);
+      h = h + (winRef.outerHeight - winRef.innerHeight);
+      settings.log.log('width: ', w, 'height:', h);
       winRef.resizeTo(w, h);
       winRef.moveTo(xy[0], xy[1]);
     } catch(e) {


### PR DESCRIPTION
r? @kumar303 This means that if we re-use the popup the payment window is the same size as if we'd just directly opened a payment window.