### PR TITLE
API URL can now be re-configured (bug 1136830)

### DIFF
--- a/lib/fxpay/adapter.js
+++ b/lib/fxpay/adapter.js
@@ -6,7 +6,6 @@
   var API = fxpay.getattr('api').API;
   var products = fxpay.getattr('products');
   var receipts = fxpay.getattr('receipts');
-  var settings = fxpay.getattr('settings');
   var utils = fxpay.getattr('utils');
 
 
@@ -22,9 +21,27 @@
     // for what public methods you need to implement if you
     // were to create your own.
     //
-    settings.log.info('using Firefox Marketplace In-App adapter');
-    this.api = new API(settings.apiUrlBase);
+    // You should avoid setting any adapter properties here
+    // that might rely on settings. Instead, use the configure()
+    // hook.
+    //
   }
+
+  FxInappAdapter.prototype.toString = function() {
+    return '<FxInappAdapter at ' + (this.api && this.api.baseUrl) + '>';
+  };
+
+  FxInappAdapter.prototype.configure = function(settings) {
+    //
+    // Adds a configuration hook for when settings change.
+    //
+    // This is called when settings are first intialized
+    // and also whenever settings are reconfigured.
+    //
+    this.settings = settings;
+    this.api = new API(settings.apiUrlBase);
+    settings.log.info('configuring Firefox Marketplace In-App adapter');
+  };
 
   FxInappAdapter.prototype.init = function(callback) {
     //
@@ -37,6 +54,7 @@
     // This must execute callback(error) when finished.
     // The error parameter should be null when there are no errors.
     //
+    var settings = this.settings;
     utils.getAppSelf(function(error, appSelf) {
       if (error) {
         return callback(error);
@@ -90,8 +108,8 @@
     opt = utils.defaults(opt, {
       productId: null
     });
-    var self = this;
-    self.api.post(settings.prepareJwtApiUrl, {inapp: opt.productId},
+    var settings = this.settings;
+    this.api.post(settings.prepareJwtApiUrl, {inapp: opt.productId},
                   function(err, productData) {
       if (err) {
         return callback(err);
@@ -125,6 +143,7 @@
     //   /In-app_payments_section/fxPay_iap#Product_Info_Object
     //
     var self = this;
+    var settings = this.settings;
 
     var url = self.api.url(transData.productData.contribStatusURL,
                            {versioned: false});
@@ -155,6 +174,7 @@
     //
     // Private helper method to finish transactionStatus().
     //
+    var settings = this.settings;
     settings.log.info('received completed transaction:', data);
 
     receipts.add(data.receipt, function(err) {

--- a/lib/fxpay/index.js
+++ b/lib/fxpay/index.js
@@ -20,13 +20,8 @@
   };
 
 
-  // Initialize settings with default values.
-  exports.configure({}, {reset: true});
-
-
   exports.init = function _init(opt) {
-    opt = opt || {};
-    exports.configure(opt);
+    settings.initialize(opt);
 
     settings.adapter.init(function(err) {
       if (err) {
@@ -39,6 +34,7 @@
 
 
   exports.validateAppReceipt = function validateAppReceipt(callback) {
+    settings.initialize();
     var defaultProductInfo = {};
     utils.getAppSelf(function(error, appSelf) {
       if (error) {
@@ -96,6 +92,7 @@
 
 
   exports.purchase = function _purchase(productId, onPurchase, opt) {
+    settings.initialize();
     opt = utils.defaults(opt, {
       maxTries: undefined,
       managePaymentWindow: undefined,

--- a/lib/fxpay/settings.js
+++ b/lib/fxpay/settings.js
@@ -44,6 +44,8 @@
     // This will be the App object returned from mozApps.getSelf().
     // On platforms that do not implement mozApps it will be false.
     appSelf: null,
+    // True if configuration has been run at least once.
+    alreadyConfigured: false,
     // Map of JWT types to payment provider URLs.
     payProviderUrls: {
       'mozilla/payments/pay/v1':
@@ -81,12 +83,24 @@
   };
 
   exports.configure = function settings_configure(newSettings, opt) {
+    //
+    // Configure new settings values.
+    //
     opt = opt || {};
+
+    // On first run, we always need to reset.
+    if (!exports.alreadyConfigured) {
+      opt.reset = true;
+    }
+
+    // Reset existing configuration.
     if (opt.reset) {
       for (var def in defaultSettings) {
         exports[def] = defaultSettings[def];
       }
     }
+
+    // Merge new values into existing configuration.
     for (var param in newSettings) {
       if (typeof exports[param] === 'undefined') {
         exports.log.error('configure() received an unknown setting:', param);
@@ -95,6 +109,7 @@
       exports[param] = newSettings[param];
     }
 
+    // Set some implied values from other parameters.
     if (exports.extraProviderUrls) {
       exports.log.info('adding extra pay provider URLs',
                        exports.extraProviderUrls);
@@ -102,22 +117,43 @@
         exports.payProviderUrls[paySpec] = exports.extraProviderUrls[paySpec];
       }
     }
-
-    var DefaultAdapter = fxpay.getattr('adapter').FxInappAdapter;
-    if (!exports.adapter) {
-      exports.log.info('using default adapter');
-      exports.adapter = new DefaultAdapter();
-    } else {
-      exports.log.info('using custom adapter');
-    }
-
     if (exports.fakeProducts) {
       exports.allowTestReceipts = true;
     }
 
-    exports.log.info('fxpay version:', exports.libVersion);
+    // Construct our in-app payments adapter.
+    var DefaultAdapter = fxpay.getattr('adapter').FxInappAdapter;
+    if (!exports.adapter) {
+      exports.log.info('creating default adapter');
+      exports.adapter = new DefaultAdapter();
+    }
+
+    // Configure the new adapter or re-configure an existing adapter.
+    exports.adapter.configure(exports);
+    exports.log.info('using adapter:', exports.adapter.toString());
+
+    exports.log.info('(re)configuration completed; fxpay version:',
+                     exports.libVersion);
+    exports.alreadyConfigured = true;
 
     return exports;
+  };
+
+
+  exports.initialize = function(newSettings) {
+    //
+    // A hook to ensure that settings have been initialized.
+    // Any public fxpay method that a user may call should call
+    // this at the top. It can be called repeatedly without harm.
+    //
+    // When a newSettings object is defined, all settings will be
+    // reconfigured with those values.
+    //
+    if (typeof newSettings === 'object' && newSettings) {
+      exports.configure(newSettings);
+    } else if (!exports.alreadyConfigured) {
+      exports.configure();
+    }
   };
 
 })();

--- a/tests/test-settings.js
+++ b/tests/test-settings.js
@@ -1,0 +1,120 @@
+describe('fxpay.settings', function() {
+  var settings = fxpay.settings;
+  var adapterConfigure;
+  var adapter;
+
+  var Adapter = function() {};
+  Adapter.prototype.configure = function() {};
+
+  beforeEach(function() {
+    settings.configure({}, {reset: true});
+    adapter = new Adapter();
+    adapterConfigure = sinon.spy(adapter, 'configure');
+  });
+
+  afterEach(function() {
+    settings.configure({}, {reset: true});
+  });
+
+  it('should allow you to set an adapter', function() {
+    settings.configure({adapter: adapter});
+    assert.equal(adapterConfigure.called, true);
+  });
+
+  it('should reconfigure the adapter', function() {
+    settings.configure({adapter: adapter});
+    // The adapter should always be reconfigured.
+    settings.configure();
+    assert.equal(adapterConfigure.callCount, 2);
+  });
+
+  it('should let you merge in new parameters', function() {
+    assert.equal(settings.allowTestReceipts, false);
+    settings.configure({allowTestReceipts: true});
+    assert.equal(settings.allowTestReceipts, true);
+    // Configuring something else should preserve old values.
+    settings.configure({apiUrlBase: 'https://mysite.net'});
+    assert.equal(settings.allowTestReceipts, true);
+  });
+
+  it('should allow test receipts for fake products', function() {
+    settings.configure({fakeProducts: true});
+    assert.equal(settings.allowTestReceipts, true);
+  });
+
+  it('should merge in new payment providers', function() {
+    var prodDefault = settings.payProviderUrls['mozilla/payments/pay/v1'];
+    var newProviders = {
+      'mysite/pay/v1': 'https://mysite.net/pay/?req={jwt}',
+    };
+    settings.configure({extraProviderUrls: newProviders});
+    assert.equal(settings.payProviderUrls['mozilla/payments/pay/v1'],
+                 prodDefault);
+    assert.equal(settings.payProviderUrls['mysite/pay/v1'],
+                 newProviders['mysite/pay/v1']);
+  });
+
+  it('should let you initialize settings with values', function() {
+    settings.initialize({allowTestReceipts: true});
+    assert.equal(settings.allowTestReceipts, true);
+  });
+
+  it('should only initialize settings once', function() {
+    settings.alreadyConfigured = false;
+    settings.initialize();
+
+    var defaultConfigure = sinon.spy(settings.adapter, 'configure');
+
+    settings.initialize();
+    settings.initialize();
+
+    // Make sure repeated calls do not re-configure.
+    assert.equal(defaultConfigure.callCount, 0);
+  });
+
+  it('does not re-initialize settings with null parameters', function() {
+    settings.alreadyConfigured = false;
+    settings.initialize();
+
+    var defaultConfigure = sinon.spy(settings.adapter, 'configure');
+
+    settings.initialize(null);
+
+    // Make sure repeated calls do not re-configure.
+    assert.equal(defaultConfigure.callCount, 0);
+  });
+
+  it('should only allow you to re-initialize settings', function() {
+    var defaultConfigure = sinon.spy(settings.adapter, 'configure');
+
+    settings.initialize({allowTestReceipts: true});
+    settings.initialize({allowTestReceipts: true});
+
+    // Since we passed in new settings, each call should reconfigure.
+    assert.equal(defaultConfigure.callCount, 2);
+  });
+
+  it('initializes settings with defaults on first run', function() {
+    var nonDefaultValue = 'not-a-default-value';
+    settings.allowTestReceipts = nonDefaultValue;
+
+    settings.alreadyConfigured = false;
+    settings.initialize();
+
+    // This ensures that the first run resets all settings.
+    assert.ok(settings.allowTestReceipts !== nonDefaultValue);
+  });
+
+  it('initializes settings with defaults even with overrides', function() {
+    var nonDefaultValue = 'not-a-default-value';
+    settings.allowTestReceipts = nonDefaultValue;
+
+    settings.alreadyConfigured = false;
+    settings.initialize({log: console});
+
+    // This ensures that the first run resets all settings even
+    // if the first initialize call overrode some values.
+    assert.ok(settings.allowTestReceipts !== nonDefaultValue);
+  });
+
+});


### PR DESCRIPTION
This also makes settings initialization lazy which
solves a lot of other subtle issues I've seen, mostly
relating to the adapter.

@muffinresearch r?

The Fireplace adapter needs fixing before this code is in use by Fireplace: https://bugzilla.mozilla.org/show_bug.cgi?id=1136843