### PR TITLE
Allow overriding the karma log-level from the grunt cli

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,7 +42,8 @@ module.exports = function(grunt) {
           // Allow an optional pattern for test files with --tests.
           {pattern: grunt.option('tests') || 'tests/test*.js',
            included: true}
-        ])
+        ]),
+        logLevel: grunt.option('log-level') || 'ERROR',
       },
       dev: {
         configFile: 'karma.conf.js',


### PR DESCRIPTION
means you can do:  `grunt  test --log-level=DEBUG` to turn karma logging up to 11.