### PR TITLE
Fix missing bower setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ This is pretty standard for any Node project so you you might already have it.
 To test that you have your path set up, type `which grunt` and make
 sure you see a path to the executable.
 
+Before going any further, you'll need to install the bower components
+used for development. Run this:
+
+    grunt bower
+
 ### Compression
 
 To build yourself a compressed version of `fxpay.js`, run this:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "almond": "^0.3.1",
     "async": "0.9.0",
+    "bower": "^1.4.1",
     "chai": "1.9.1",
     "grunt": "^0.4.5",
     "grunt-banner": "^0.3.1",


### PR DESCRIPTION
@muffinresearch r?

I'm setting up a new machine and I was running into this error that I think you also saw while running `grunt test`:

    Firefox 37.0.0 (Mac OS X 10.10) ERROR: 'There is no timestamp for /base/lib/bower_components/es6-promise/promise.js!'

This patch seems necessary but it doesn't actually fix the error. Any ideas on how to fix it? 