### PR TITLE
Support non-privileged packaged apps (fixes #116)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,10 +104,22 @@ module.exports = function(grunt) {
         dest: 'build/app/',
         expand: true,
       },
-      'example-shared': {
+      'example-packaged-web': {
+        cwd: 'example/packaged-web/',
+        src: '*',
+        dest: 'build/app-web/',
+        expand: true,
+      },
+      'example-shared-to-pkg': {
         cwd: 'example/shared/',
         src: '**/*',
         dest: 'build/app/',
+        expand: true,
+      },
+      'example-shared-to-web-pkg': {
+        cwd: 'example/shared/',
+        src: '**/*',
+        dest: 'build/app-web/',
         expand: true,
       },
       'lib-to-package': {
@@ -115,7 +127,13 @@ module.exports = function(grunt) {
         src: '*',
         dest: 'build/app/',
         expand: true,
-      }
+      },
+      'lib-to-web-package': {
+        cwd: 'build/lib/',
+        src: '*',
+        dest: 'build/app-web/',
+        expand: true,
+      },
     },
 
     zip: {
@@ -124,7 +142,13 @@ module.exports = function(grunt) {
         src: 'build/app/**',
         dest: 'build/app.zip',
         compression: 'DEFLATE',
-      }
+      },
+      appWeb: {
+        cwd: 'build/app-web/',
+        src: 'build/app-web/**',
+        dest: 'build/app-web.zip',
+        compression: 'DEFLATE',
+      },
     },
 
     jsdoc : {
@@ -237,8 +261,11 @@ module.exports = function(grunt) {
     'clean:build',
     'compress',
     'copy:example-packaged',
-    'copy:example-shared',
+    'copy:example-packaged-web',
+    'copy:example-shared-to-pkg',
+    'copy:example-shared-to-web-pkg',
     'copy:lib-to-package',
+    'copy:lib-to-web-package',
     'zip',
   ]);
 

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "fxpay",
   "description": "Adds Firefox Marketplace payments to a web application",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "homepage": "https://github.com/mozilla/fxpay",
   "repository": {
     "type": "git",

--- a/example/README.rst
+++ b/example/README.rst
@@ -9,11 +9,14 @@ play around with them.
 `hosted app with in-app purchases <hosted/>`_
     A hosted web app that can sell and restore in-app products.
 
-`packaged app with in-app purchases <packaged/>`_
-    A packaged app that can sell and restore in-app products.
-
 `hosted paid app <hosted-paid-app/>`_
     A hosted web app that validates its receipt to ensure the user paid for it.
+
+`packaged web app with in-app purchases <packaged-web/>`_
+    A packaged app (``type: web``) that can sell and restore in-app products.
+
+`privileged packaged app with in-app purchases <packaged/>`_
+    A packaged app (``type: privileged``) that can sell and restore in-app products.
 
 Using A Custom Webpay
 ---------------------

--- a/example/packaged-web/README.rst
+++ b/example/packaged-web/README.rst
@@ -1,0 +1,26 @@
+======================================
+Packaged Web App With In-App Purchases
+======================================
+
+This is an example of a `packaged app`_ of `type:web` (meaning it is not
+privileged) that uses the fxpay library to sell and restore in-app products.
+
+By default packaged apps get a random origin but fxpay needs a
+reliable origin to look up in-app products. This shows how you can still
+use a web package having no origin to do in-app payments.
+
+Installation
+~~~~~~~~~~~~
+
+First, build this example into a packaged app. Run this from the root
+of the fxpay repository
+after you've installed the developer tools listed in the main README::
+
+    grunt package
+
+This will create ``build/app-web`` and ``build/app-web.zip``.
+You can install the app from that directory using the `WebIDE`_.
+
+.. _`packaged app`: https://developer.mozilla.org/en-US/Marketplace/Options/Packaged_apps
+.. _`WebIDE`: https://developer.mozilla.org/en-US/docs/Tools/WebIDE
+.. _`Firefox Marketplace`: https://marketplace.firefox.com/

--- a/example/packaged-web/manifest.webapp
+++ b/example/packaged-web/manifest.webapp
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "name": "FxPay Web Package",
+  "description": "Example of a packaged app of type:web that can do server-less in-app payments",
+  "developer": {
+      "name": "Kumar McMillan"
+   },
+  "icons": {
+    "128": "/img/kiwi_128.png",
+    "64": "/img/kiwi_64.png",
+    "48": "/img/kiwi_48.png",
+    "32": "/img/kiwi_32.png"
+  },
+  "launch_path": "/index.html",
+  "installs_allowed_from": ["*"],
+  "type": "web"
+}

--- a/lib/fxpay/errors.js
+++ b/lib/fxpay/errors.js
@@ -11,18 +11,26 @@ define([
   exports.FxPayError = createError('FxPayError');
 
   exportErrors([
+    ['ApiError'],
     ['ConfigurationError'],
     ['FailedWindowMessage'],
     ['IncorrectUsage'],
     ['InvalidApp'],
     ['InvalidJwt'],
     ['NotImplementedError'],
+    ['PaymentFailed'],
     ['PayWindowClosedByUser', {code: 'DIALOG_CLOSED_BY_USER'}],
+    ['PlatformError'],
     ['UnknownMessageOrigin'],
   ]);
 
 
-  exports.PaymentFailed = createError('PaymentFailed');
+  exportErrors([
+    ['InvalidAppOrigin'],
+  ], {
+    inherits: exports.InvalidApp,
+  });
+
 
   exportErrors([
     ['AppReceiptMissing'],
@@ -34,8 +42,6 @@ define([
   });
 
 
-  exports.PlatformError = createError('PlatformError');
-
   exportErrors([
     ['AddReceiptError'],
     ['PayPlatformError'],
@@ -44,8 +50,6 @@ define([
     inherits: exports.PlatformError,
   });
 
-
-  exports.ApiError = createError('ApiError');
 
   exportErrors([
     ['ApiRequestAborted'],

--- a/lib/fxpay/products.js
+++ b/lib/fxpay/products.js
@@ -37,20 +37,15 @@ define([
       .then(function() {
         return new Promise(function(resolve, reject) {
           var allProducts = [];
-
+          var origin;
           var api = new apiModule.API(settings.apiUrlBase);
-          var origin = utils.getSelfOrigin();
-          if (!origin) {
-            return reject(
-                errors.InvalidApp('an origin is needed to get products'));
-          }
-          origin = encodeURIComponent(origin);
           var url;
 
           if (settings.fakeProducts) {
             settings.log.warn('about to fetch fake products');
             url = '/payments/stub-in-app-products/';
           } else {
+            origin = encodeURIComponent(utils.getSelfOrigin());
             settings.log.info('about to fetch real products for app',
                               origin);
             url = '/payments/' + origin + '/in-app/?active=1';

--- a/lib/fxpay/settings.js
+++ b/lib/fxpay/settings.js
@@ -5,7 +5,7 @@ define([
 ], function(exports, adapter, errors) {
 
   'use strict';
-  var pkgInfo = {"version": "0.0.17"};  // this is updated by `grunt bump`
+  var pkgInfo = {"version": "0.0.18"};  // this is updated by `grunt bump`
 
   var defaultSettings = {
 

--- a/lib/fxpay/utils.js
+++ b/lib/fxpay/utils.js
@@ -34,11 +34,39 @@ define([
   */
   exports.getSelfOrigin = function(settingsObj) {
     settingsObj = settingsObj || settings;
+
     if (settingsObj.appSelf) {
-      // This might be null for type:web packaged apps.
-      // If that's a requirement, the caller should check for nulls.
+      // Check the manifest-declared origin (not the auto-generated one).
+      var hasDeclaredOrigin = !!settingsObj.appSelf.manifest.origin;
+
+      if (settingsObj.appSelf.manifest.type === 'web' || !hasDeclaredOrigin) {
+        // This package does not have a reliable origin so
+        // here we look for its marketplace hosted package URL
+        // to derive a marketplace-specific origin.
+        var pat = new RegExp(
+          '^https?://(?:marketplace|mp\\.dev).*/app/([^/]+)/manifest\\.webapp$'
+        );
+        var match = pat.exec(settingsObj.appSelf.manifestURL);
+        if (!match) {
+          throw new errors.InvalidAppOrigin(
+            'Cannot derive marketplace GUID from "' +
+            settingsObj.appSelf.manifestURL +
+            '". The package must be installed from the Firefox Marketplace ' +
+            'or define an origin. For local testing, use fake products.'
+          );
+        }
+        // Create an origin out of the marketplace GUID.
+        var marketplaceOrigin = 'marketplace:' + match[1];
+        settingsObj.log.info('derived marketplace origin as', marketplaceOrigin,
+                             'from URL', settingsObj.appSelf.manifestURL);
+        return marketplaceOrigin;
+      }
+
+      // Trust the declared origin from a privileged/certified app.
       return settingsObj.appSelf.origin;
+
     } else {
+      // Get the origin from a non-app website.
       var win = settingsObj.window;
       if (win.location.origin) {
         return win.location.origin;
@@ -162,7 +190,7 @@ define([
       var appSelf = this.result;
       // In the case where we're in a Firefox that supports mozApps but
       // we're not running as an app, this could be falsey.
-      settings.log.info('got appSelf from mozApps.getSelf()');
+      settings.log.info('got appSelf from mozApps.getSelf():', appSelf);
       callback(null, storeAppSelf(appSelf || false));
     };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fxpay",
   "description": "Adds Firefox Marketplace payments to a web application",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "homepage": "https://github.com/mozilla/fxpay",
   "repository": {
     "type": "git",

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -174,9 +174,11 @@ define([
       this.origin = exports.someAppOrigin;
       this.manifest = {
         installs_allowed_from: ['*'],
+        origin: this.origin,
+        type: 'privileged',
         permissions: {
           systemXHR: {description: "Required to access payment API"}
-        }
+        },
       };
       this.receipts = [];
       // This is the result of getSelf(). Setting it to this makes

--- a/tests/test-get-products.js
+++ b/tests/test-get-products.js
@@ -101,17 +101,6 @@ define([
 
     });
 
-    it('requires an origin when running as an app', function(done) {
-      fxpay.configure({appSelf: {}});  // no origin
-
-      fxpay.getProducts().then(function() {
-        done(Error('unexpected success'));
-      }).catch(function(err) {
-        assert.instanceOf(err, errors.InvalidApp);
-        done();
-      }).catch(done);
-    });
-
     it('requires a JSON response from the server', function(done) {
 
       setUpApiResponses({serverObjects: null});

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -131,8 +131,66 @@ define([
 
     it('should return the app origin', function() {
       assert.equal(
-        utils.getSelfOrigin({appSelf: {origin: 'app://origin'}}),
+        utils.getSelfOrigin({
+          appSelf: {
+            origin: 'app://origin',
+            manifest: {
+              origin: 'app://origin',
+              type: 'privileged',
+            },
+          },
+        }),
         'app://origin');
+    });
+
+    it('should return the marketplace GUID origin', function() {
+      assert.equal(
+        utils.getSelfOrigin({
+          log: {info: function() {}},
+          appSelf: {
+            origin: 'app://unusable-origin',
+            manifest: {
+              type: 'web',
+            },
+            manifestURL: ('https://marketplace-dev.allizom.org' +
+                          '/app/some-guid/manifest.webapp'),
+          },
+        }),
+        'marketplace:some-guid');
+    });
+
+    it('should fall back to marketplace when no declared origin', function() {
+      assert.equal(
+        utils.getSelfOrigin({
+          log: {info: function() {}},
+          // Set up a privileged app that has not declared an origin.
+          appSelf: {
+            origin: 'app://unusable-origin',
+            manifest: {
+              type: 'privileged',
+              origin: null,
+            },
+            manifestURL: ('https://marketplace-dev.allizom.org' +
+                          '/app/some-guid/manifest.webapp'),
+          },
+        }),
+        'marketplace:some-guid');
+    });
+
+    it('should error on non-marketplace packages', function() {
+      assert.throws(function() {
+        utils.getSelfOrigin({
+          appSelf: {
+            // This would be a randomly generated origin by the platform.
+            origin: 'app://unusable-origin',
+            manifest: {
+              type: 'web',
+              origin: null,
+            },
+            manifestURL: 'http://some-random-site/f/manifest.webapp',
+          },
+        });
+      }, errors.InvalidAppOrigin);
     });
 
     it('should fall back to location origin', function() {
@@ -149,6 +207,7 @@ define([
         utils.getSelfOrigin({window: {location: stubLocation}}),
         'http://foo.com:3000');
     });
+
   });
 
 


### PR DESCRIPTION
This depends on a zamboni patch but it won't
break anything until then. Web packages were always
broken, they just never returned product results.
